### PR TITLE
Added URL to extension page + description

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -2,6 +2,8 @@
 	"name": "Counter",
 	"type": "parserhook",
 	"author": [ "Original code by Rinick", "Adapted to modern MediaWiki by Johannes Schultz" ],
+	"url": "https://www.mediawiki.org/wiki/Extension:Counter",
+	"description": "Adds <code><nowiki>{{#+:}}</nowiki></code> and <code><nowiki>{{#+: ?}}</nowiki></code> parser function hooks to implement simple counters",
 	"ExtensionMessagesFiles": {
 		"CounterMagic": "Counter.magic.php"
 	},


### PR DESCRIPTION
URL so it links to the extension page at MediaWiki.org, and a description to briefly explain the extension.